### PR TITLE
[SDL-0249] add check allowMultipleAccess by default

### DIFF
--- a/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
@@ -118,22 +118,30 @@ function m.checkContentOfCapabilityCacheFile(pExpHmiCapabilities)
       for req, params in pairs(requests) do
         for _, param in ipairs(params) do
           local message = mod .. "." .. param
-          if param == "audioPassThruCapabilitiesList" then
-            if not utils.isTableEqual(cacheTable[mod].audioPassThruCapabilities, expHmiCapabilities[mod][req].params[param]) then
-              errorMessages = errorMessages ..
-                errorMessage(message, cacheTable[mod].audioPassThruCapabilities,
-                  expHmiCapabilities[mod][req].params[param])
-            end
-          else
-            if not cacheTable[mod][param] then
-              errorMessages = errorMessages ..
-                errorMessage(message, "does not exist", expHmiCapabilities[mod][req].params[param])
-            else
-              if not utils.isTableEqual(cacheTable[mod][param], expHmiCapabilities[mod][req].params[param]) then
+          if not cacheTable[mod][param] then
+            errorMessages = errorMessages ..
+              errorMessage(message, "does not exist", expHmiCapabilities[mod][req].params[param])
+          elseif param == "audioPassThruCapabilitiesList" then
+            if not utils.isTableEqual(cacheTable[mod].audioPassThruCapabilities,
+              expHmiCapabilities[mod][req].params[param]) then
                 errorMessages = errorMessages ..
-                  errorMessage(message, cacheTable[mod][param], expHmiCapabilities[mod][req].params[param])
+                  errorMessage(message, cacheTable[mod].audioPassThruCapabilities,
+                    expHmiCapabilities[mod][req].params[param])
+            end
+          elseif param == "remoteControlCapability" then
+            for _, buttonCap in ipairs(expHmiCapabilities[mod][req].params[param].buttonCapabilities) do
+              if buttonCap.moduleInfo.allowMultipleAccess == nil then
+                buttonCap.moduleInfo.allowMultipleAccess = true
               end
             end
+            if not utils.isTableEqual(cacheTable[mod][param], expHmiCapabilities[mod][req].params[param]) then
+              errorMessages = errorMessages ..
+                errorMessage(message, cacheTable[mod][param],
+                  expHmiCapabilities[mod][req].params[param])
+            end
+          elseif not utils.isTableEqual(cacheTable[mod][param], expHmiCapabilities[mod][req].params[param]) then
+            errorMessages = errorMessages ..
+              errorMessage(message, cacheTable[mod][param], expHmiCapabilities[mod][req].params[param])
           end
         end
       end

--- a/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
@@ -81,7 +81,7 @@ function m.checkContentOfCapabilityCacheFile(pExpHmiCapabilities)
     expHmiCapabilities = pExpHmiCapabilities
   end
   local cacheTable = SDL.HMICapCache.get()
-  if next(cacheTable) ~= nil then
+  if cacheTable ~= nil then
     local hmiCheckingParametersMap = {
       UI = {
         GetLanguage = { "language" },

--- a/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
@@ -114,23 +114,22 @@ function m.checkContentOfCapabilityCacheFile(pExpHmiCapabilities)
       }
     }
     local errorMessages = ""
+    local function validationCapabilities(pMessage, pActual, pExpect)
+      if not utils.isTableEqual(pActual, pExpect) then
+        errorMessages = errorMessages .. errorMessage(pMessage, pActual, pExpect)
+      end
+    end
     for mod, requests  in pairs(hmiCheckingParametersMap) do
       for req, params in pairs(requests) do
         for _, param in ipairs(params) do
           local message = mod .. "." .. param
           local expectedResult = expHmiCapabilities[mod][req].params[param]
-          local function validationCapabilities(pActual, pExpect)
-            if not utils.isTableEqual(pActual, pExpect) then
-              errorMessages = errorMessages .. errorMessage(message, pActual, pExpect)
-            end
-          end
-
           if not cacheTable[mod][param] then
             errorMessages = errorMessages ..
               errorMessage(message, "does not exist", expectedResult)
           else
             if param == "audioPassThruCapabilitiesList" then
-              validationCapabilities(cacheTable[mod].audioPassThruCapabilitie, expectedResult)
+              validationCapabilities(message, cacheTable[mod].audioPassThruCapabilitie, expectedResult)
             else
               if param == "remoteControlCapability" then
               for _, buttonCap in ipairs(expectedResult.buttonCapabilities) do
@@ -138,9 +137,9 @@ function m.checkContentOfCapabilityCacheFile(pExpHmiCapabilities)
                   buttonCap.moduleInfo.allowMultipleAccess = true
                 end
               end
-              validationCapabilities(cacheTable[mod][param], expectedResult)
+              validationCapabilities(message, cacheTable[mod][param], expectedResult)
               else
-                validationCapabilities(cacheTable[mod][param], expectedResult)
+                validationCapabilities(message, cacheTable[mod][param], expectedResult)
               end
             end
           end

--- a/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/common.lua
@@ -118,30 +118,31 @@ function m.checkContentOfCapabilityCacheFile(pExpHmiCapabilities)
       for req, params in pairs(requests) do
         for _, param in ipairs(params) do
           local message = mod .. "." .. param
+          local expectedResult = expHmiCapabilities[mod][req].params[param]
+          local function validationCapabilities(pActual, pExpect)
+            if not utils.isTableEqual(pActual, pExpect) then
+              errorMessages = errorMessages .. errorMessage(message, pActual, pExpect)
+            end
+          end
+
           if not cacheTable[mod][param] then
             errorMessages = errorMessages ..
-              errorMessage(message, "does not exist", expHmiCapabilities[mod][req].params[param])
-          elseif param == "audioPassThruCapabilitiesList" then
-            if not utils.isTableEqual(cacheTable[mod].audioPassThruCapabilities,
-              expHmiCapabilities[mod][req].params[param]) then
-                errorMessages = errorMessages ..
-                  errorMessage(message, cacheTable[mod].audioPassThruCapabilities,
-                    expHmiCapabilities[mod][req].params[param])
-            end
-          elseif param == "remoteControlCapability" then
-            for _, buttonCap in ipairs(expHmiCapabilities[mod][req].params[param].buttonCapabilities) do
-              if buttonCap.moduleInfo.allowMultipleAccess == nil then
-                buttonCap.moduleInfo.allowMultipleAccess = true
+              errorMessage(message, "does not exist", expectedResult)
+          else
+            if param == "audioPassThruCapabilitiesList" then
+              validationCapabilities(cacheTable[mod].audioPassThruCapabilitie, expectedResult)
+            else
+              if param == "remoteControlCapability" then
+              for _, buttonCap in ipairs(expectedResult.buttonCapabilities) do
+                if buttonCap.moduleInfo.allowMultipleAccess == nil then
+                  buttonCap.moduleInfo.allowMultipleAccess = true
+                end
+              end
+              validationCapabilities(cacheTable[mod][param], expectedResult)
+              else
+                validationCapabilities(cacheTable[mod][param], expectedResult)
               end
             end
-            if not utils.isTableEqual(cacheTable[mod][param], expHmiCapabilities[mod][req].params[param]) then
-              errorMessages = errorMessages ..
-                errorMessage(message, cacheTable[mod][param],
-                  expHmiCapabilities[mod][req].params[param])
-            end
-          elseif not utils.isTableEqual(cacheTable[mod][param], expHmiCapabilities[mod][req].params[param]) then
-            errorMessages = errorMessages ..
-              errorMessage(message, cacheTable[mod][param], expHmiCapabilities[mod][req].params[param])
           end
         end
       end


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary

Added check for allowMultipleAccess value as true in case this parameter is missing in the  UI.GetCapabilities response ( {.. remoteControlCapability: {... buttonCapabilities:{... moduleInfo: { }...}}})

<param name="allowMultipleAccess" type="Boolean" mandatory="false" defvalue="true">
SDL should treat allowMultipleAccess value as true in case this parameter is missing in the message. 
SDL persists these default values to the HMICapabilitiesCacheFile (hmi_capabilities_cache.json) file.


