### PR TITLE
[SDL-0249] - Temporarily exclude text fields that are absent in Mobile API from checks

### DIFF
--- a/test_scripts/Capabilities/PersistingHMICapabilities/020_RAI_use_default_capability_cash_file_is_not_exist.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/020_RAI_use_default_capability_cash_file_is_not_exist.lua
@@ -55,6 +55,7 @@ local capRaiResponse = {
 --[[ Scenario ]]
 common.Title("Preconditions")
 common.Step("Clean environment", common.preconditions)
+common.Step("Update HMI capabilities", common.updateHMICapabilitiesFile, { true })
 
 common.Title("Test")
 common.Step("Ignition on, Start SDL, HMI", common.start, { common.getHMIParamsWithOutResponse() })

--- a/test_scripts/Capabilities/PersistingHMICapabilities/028_Suspending_of_RAI_request_processing_in_case_no_cap_response.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/028_Suspending_of_RAI_request_processing_in_case_no_cap_response.lua
@@ -69,6 +69,7 @@ end
 --[[ Scenario ]]
 common.Title("Preconditions")
 common.Step("Clean environment", common.preconditions)
+common.Step("Update HMI capabilities", common.updateHMICapabilitiesFile, { true })
 common.Step("Start SDL, HMI", common.startWoHMIonReady)
 
 common.Title("Test")

--- a/test_scripts/Capabilities/PersistingHMICapabilities/031_Suspending_of_RAI_request_processing_in_case_cash_file_does_not_exist_no_cap_response.lua
+++ b/test_scripts/Capabilities/PersistingHMICapabilities/031_Suspending_of_RAI_request_processing_in_case_cash_file_does_not_exist_no_cap_response.lua
@@ -73,6 +73,7 @@ end
 --[[ Scenario ]]
 common.Title("Preconditions")
 common.Step("Clean environment", common.preconditions)
+common.Step("Update HMI capabilities", common.updateHMICapabilitiesFile, { true })
 common.Step("Start SDL, HMI", common.start, { getHMIParamsWithOutResponse(ccpuVersion) })
 common.Step("Check that capabilities file doesn't exist", common.checkIfCapabilityCacheFileExists, { false })
 common.Step("Ignition off", common.ignitionOff)


### PR DESCRIPTION
This PR is **[ready]** for review.

### Summary
This fix temporarily removes text fields which are absent in Mobile API from checks. 
It should be reverted after Mobile API is aligned  with HMI API

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
