### PR TITLE
[SDL-0188] Update of regression scripts according to WARNING resultCode

### DIFF
--- a/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/014_Absence_of_subscribe_parameter_in_request_for_HMI_in_case_of_2nd_Subscription_UnSubscription.lua
+++ b/test_scripts/RC/AUDIO_LIGHT_HMI_SETTINGS/GetInteriorVehicleData/014_Absence_of_subscribe_parameter_in_request_for_HMI_in_case_of_2nd_Subscription_UnSubscription.lua
@@ -34,14 +34,14 @@ local common = require("test_scripts/RC/commonRC")
 runner.testSettings.isSelfIncluded = false
 
 --[[ Local Functions ]]
-local function subscriptionToModule(pModuleType, pSubscribe, pHMIReqTimes)
+local function subscriptionToModule(pModuleType, pSubscribe, pHMIReqTimes, pResultCode)
   local mobileSession = common.getMobileSession()
   local cid = mobileSession:SendRPC("GetInteriorVehicleData", {
       moduleType = pModuleType,
       subscribe = pSubscribe
     })
 
-  EXPECT_HMICALL("RC.GetInteriorVehicleData", {
+  common.getHMIConnection():ExpectRequest("RC.GetInteriorVehicleData", {
       moduleType = pModuleType
     })
   :Do(function(_, data)
@@ -58,7 +58,8 @@ local function subscriptionToModule(pModuleType, pSubscribe, pHMIReqTimes)
     end)
   :Times(pHMIReqTimes)
 
-  mobileSession:ExpectResponse(cid, { success = true, resultCode = "SUCCESS",
+  local resultCode = pResultCode or "SUCCESS"
+  mobileSession:ExpectResponse(cid, { success = true, resultCode = resultCode,
       moduleData = common.getModuleControlDataForResponse(pModuleType),
       isSubscribed = pSubscribe
     })
@@ -85,7 +86,7 @@ for _, mod in pairs(common.modulesWithoutSeat) do
     { mod })
 
   -- subscribe to module 2nd time
-  runner.Step("Subscribe 2nd time app to " .. mod, subscriptionToModule, { mod, true, 0 })
+  runner.Step("Subscribe 2nd time app to " .. mod, subscriptionToModule, { mod, true, 0, "WARNINGS" })
   runner.Step("Send notification OnInteriorVehicleData " .. mod .. ". App is subscribed", common.isSubscribed,
     { mod })
 

--- a/test_scripts/RC/InteriorVehicleData_cache/000_cache_2_apps_sequence.lua
+++ b/test_scripts/RC/InteriorVehicleData_cache/000_cache_2_apps_sequence.lua
@@ -65,7 +65,7 @@ for _, mod in pairs(common.modules) do
   runner.Step("App1 OnInteriorVehicleData for " .. mod, common.OnInteriorVD,
     { mod, true, 1 })
   runner.Step("App1 GetInteriorVehicleData with subscribe=true without request to HMI " .. mod, common.GetInteriorVehicleData,
-    { mod, true, false, 1 })
+    { mod, true, false, 1 , "WARNINGS" })
   runner.Step("App1 GetInteriorVehicleData without request to HMI " .. mod, common.GetInteriorVehicleData,
     { mod, nil, false, 1 })
   -- Block 'Subscribe app2' from diagram

--- a/test_scripts/RC/InteriorVehicleData_cache/005_GetInteriorVD_subscribe_true_2_requests.lua
+++ b/test_scripts/RC/InteriorVehicleData_cache/005_GetInteriorVD_subscribe_true_2_requests.lua
@@ -32,7 +32,7 @@ for _, mod in pairs(common.modules) do
   runner.Step("GetInteriorVehicleData with subscribe=true " .. mod, common.GetInteriorVehicleData,
     { mod, true, true, 1 })
   runner.Step("GetInteriorVehicleData with subscribe=true second request " .. mod, common.GetInteriorVehicleData,
-    { mod, true, false, 1 })
+    { mod, true, false, 1, "WARNINGS" })
 end
 
 runner.Title("Postconditions")

--- a/test_scripts/RC/InteriorVehicleData_cache/010_GetInteriorVD_subscribe_true_2_apps_same_module.lua
+++ b/test_scripts/RC/InteriorVehicleData_cache/010_GetInteriorVD_subscribe_true_2_apps_same_module.lua
@@ -37,7 +37,7 @@ for _, mod in pairs(common.modules) do
   runner.Step("App2 GetInteriorVehicleData with subscribe=true " .. mod, common.GetInteriorVehicleData,
     { mod, true, false, 2 })
   runner.Step("App2 GetInteriorVehicleData with subscribe=true second request " .. mod, common.GetInteriorVehicleData,
-    { mod, true, false, 2 })
+    { mod, true, false, 2, "WARNINGS" })
 end
 
 runner.Title("Postconditions")

--- a/test_scripts/RC/InteriorVehicleData_cache/common_interiorVDcache.lua
+++ b/test_scripts/RC/InteriorVehicleData_cache/common_interiorVDcache.lua
@@ -18,7 +18,7 @@ config.application2.registerAppInterfaceParams.isMediaApplication = false
 commonRC.modules = { "RADIO", "CLIMATE", "SEAT", "AUDIO", "LIGHT", "HMI_SETTINGS" }
 commonRC.functionId = functionId
 
-function commonRC.GetInteriorVehicleData(pModuleType, isSubscribe, isHMIreqExpect, pAppId)
+function commonRC.GetInteriorVehicleData(pModuleType, isSubscribe, isHMIreqExpect, pAppId, pResultCode)
   if not pAppId then pAppId = 1 end
   local rpc = "GetInteriorVehicleData"
   local HMIrequestsNumber
@@ -35,7 +35,8 @@ function commonRC.GetInteriorVehicleData(pModuleType, isSubscribe, isHMIreqExpec
       commonRC.getHMIResponseParams(rpc, pModuleType, isSubscribe))
     end)
   :Times(HMIrequestsNumber)
-  commonRC.getMobileSession(pAppId):ExpectResponse(cid, commonRC.getAppResponseParams(rpc, true, "SUCCESS", pModuleType, isSubscribe))
+  local resultCode = pResultCode or "SUCCESS"
+  commonRC.getMobileSession(pAppId):ExpectResponse(cid, commonRC.getAppResponseParams(rpc, true, resultCode, pModuleType, isSubscribe))
 end
 
 function commonRC.GetInteriorVehicleDataRejected(pModuleType, isSubscribe, pAppId)


### PR DESCRIPTION
ATF Test Scripts to check [FORDTCN-7211](https://adc.luxoft.com/jira/browse/FORDTCN-7211)
This PR is **[ready]** for review.

### Summary
 Update of regression scripts according to WARNING resultCode because of the double subscription

### ATF version
develop

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
