### PR TITLE
[SDL-0188] - Add info message for double subscription

### DIFF
--- a/test_scripts/Resumption/InteriorVehicleData/026_InteriorVD_resumption_double_subscription_with_moduleId_unexpected_disconnect.lua
+++ b/test_scripts/Resumption/InteriorVehicleData/026_InteriorVD_resumption_double_subscription_with_moduleId_unexpected_disconnect.lua
@@ -31,7 +31,6 @@ local isCached = true
 local isNotCached = false
 local appSessionId = 1
 
-
 --[[ Local Functions ]]
 local function checkResumptionData()
   local actualModules = { }

--- a/test_scripts/Resumption/InteriorVehicleData/commonResumptionsInteriorVD.lua
+++ b/test_scripts/Resumption/InteriorVehicleData/commonResumptionsInteriorVD.lua
@@ -106,8 +106,11 @@ function  m.GetInteriorVehicleData(pModuleType, pModuleId, isSubscribe, pIsIVDat
     end)
 
   local resultCode = pResultCode or "SUCCESS"
-  m.getMobileSession(pAppId):ExpectResponse(cid,
-    rc.rpc.getAppResponseParams(rpc, true, resultCode, pModuleType, moduleId, isSubscribe))
+  local responseParams = rc.rpc.getAppResponseParams(rpc, true, resultCode, pModuleType, moduleId, isSubscribe)
+  if pResultCode == "WARNINGS" then
+    responseParams["info"] = "App is already subscribed to the provided module"
+  end
+  m.getMobileSession(pAppId):ExpectResponse(cid, responseParams)
   :Do(function()
       setSubscriptionModuleStatus(pModuleType, moduleId, isSubscribe)
     end)


### PR DESCRIPTION
ATF Test Scripts to check [FORDTCN-7221](https://adc.luxoft.com/jira/browse/FORDTCN-7221)

This PR is **[ready]** for review.

### Summary
Add check for info message in case of the double subscription
info = "App is already subscribed to the provided module"
https://github.com/LuxoftSDL/sdl_core/pull/105/files#diff-9105ef481d516c73c053457618a4cd36R137

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
