### PR TITLE
Add REMOTE_CONTROL HMI type for the application

### DIFF
--- a/test_scripts/Resumption/Handling_errors_from_HMI/025_resume_all_data_with_one_error_rpc_unexpected_disconnect_background.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/025_resume_all_data_with_one_error_rpc_unexpected_disconnect_background.lua
@@ -27,7 +27,7 @@ local common = require('test_scripts/Resumption/Handling_errors_from_HMI/commonR
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
 config.application1.registerAppInterfaceParams.isMediaApplication = false
-config.application1.registerAppInterfaceParams.appHMIType = { "DEFAULT" }
+config.application1.registerAppInterfaceParams.appHMIType = { "DEFAULT", "REMOTE_CONTROL" }
 
 --[[ Common Functions ]]
 local function absenceResumptionToBackground()

--- a/test_scripts/Resumption/Handling_errors_from_HMI/026_resume_all_data_with_one_error_rpc_ign_off_background.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/026_resume_all_data_with_one_error_rpc_ign_off_background.lua
@@ -27,7 +27,7 @@ local common = require('test_scripts/Resumption/Handling_errors_from_HMI/commonR
 --[[ Test Configuration ]]
 runner.testSettings.isSelfIncluded = false
 config.application1.registerAppInterfaceParams.isMediaApplication = false
-config.application1.registerAppInterfaceParams.appHMIType = { "DEFAULT" }
+config.application1.registerAppInterfaceParams.appHMIType = { "DEFAULT", "REMOTE_CONTROL" }
 
 --[[ Common Functions ]]
 local function absenceResumptionToBackground()


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
This PR provides the changes with adding REMOTE_CONTROL HMI type for the test application to have ability to subscribe to the Module Data.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
