### PR TITLE
[Issue-3580] Script to check revoked app can be activated via device consent in EXTERNAL_PROPRIETARY issue

### DIFF
--- a/test_scripts/Defects/7_1/3580/001_revoked_app_activation_after_device_consent_ptu.lua
+++ b/test_scripts/Defects/7_1/3580/001_revoked_app_activation_after_device_consent_ptu.lua
@@ -1,0 +1,55 @@
+---------------------------------------------------------------------------------------------------
+-- Issue: https://github.com/smartdevicelink/sdl_core/issues/3580
+--
+-- Description: Check that SDL does not activate revoked application after device consent.
+-- Application is revoked via PTU in current ignition cycle
+--
+-- Preconditions:
+-- 1. SDL built with EXTERNAL_PROPRIETARY policy option
+-- 2  The application has no permissions in policy table
+-- 3. SDL and HMI are started
+-- 4. Device 1 and Device 2 are connected to SDL (Device 1 is consented, Device 2 is not consented)
+-- 5. The application from Device 1 is registered
+-- 6. PTU is performed. The application is set as revoked (null permissions) via PTU.
+--
+-- Sequence:
+-- 1. Try to activate the application from Device 1 via SDL.ActivateApp request from HMI
+--   a. SDL does not activate the application from Device 1 and respond to SDL.ActivateApp
+--    with isSDLAllowed = true and isAppRevoked = true parameters
+-- 2. Register the same application from Device 2
+--   a. SDL sucessfully register the application from Device 2
+-- 3. Try to activate the application from Device 2 via SDL.ActivateApp request from HMI
+--   a. SDL does not activate the application from Device 1 and respond to SDL.ActivateApp
+--    with isSDLAllowed = false and isAppRevoked = true parameters
+-- 4. Consent Device 2 from HMI via SDL.OnAllowSDLFunctionality
+--   a. SDL does not activate the application from Device 2
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/Defects/7_1/3580/common')
+
+--[[ Test Configuration ]]
+common.testSettings.restrictions.sdlBuildOptions = {{extendedPolicy = {"EXTERNAL_PROPRIETARY"}}}
+
+--[[ Local Data ]]
+local devices = {
+  [1] = { host = "1.0.0.1", port = config.mobilePort, hasAutoConsent = true },
+  [2] = { host = "192.168.100.199", port = config.mobilePort, hasAutoConsent = false },
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL and HMI", common.startWithoutMobile)
+common.Step("Connect two mobile devices to SDL", common.connectMobDevices, { devices })
+common.Step("Register App1 from device 1", common.registerApp, { 1, 1 })
+common.Step("Revoke app via PTU", common.revokeAppViaPtu)
+
+common.Title("Test")
+common.Step("Activate App1 on device 1 with device consent", common.activateRevokedApp, { 1, true })
+common.Step("Register App1 from device 2", common.registerAppNoPTU, { 2, 2 })
+common.Step("Activate App1 on device 2 without device consent", common.activateRevokedApp, { 2, false })
+common.Step("Allow SDL for Device 2", common.consentDevice, { 2 })
+
+common.Title("Postconditions")
+common.Step("Remove mobile devices", common.clearMobDevices, { devices })
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Defects/7_1/3580/002_revoked_app_activation_after_device_consent_ignition_off.lua
+++ b/test_scripts/Defects/7_1/3580/002_revoked_app_activation_after_device_consent_ignition_off.lua
@@ -1,0 +1,52 @@
+---------------------------------------------------------------------------------------------------
+-- Issue: https://github.com/smartdevicelink/sdl_core/issues/3580
+--
+-- Description: Check that SDL does not activate revoked application after device consent.
+-- Application is revoked via PTU in previous ignition cycle
+--
+-- Preconditions:
+-- 1. SDL built with EXTERNAL_PROPRIETARY policy option
+-- 2. The application is set as revoked (null permissions) via PTU in one of the previous ignition cycles
+-- 3. SDL and HMI are started
+-- 4. Not consented device is connected to SDL
+-- 5. The application is registered
+--
+-- Sequence:
+-- 1. Try to activate the application via SDL.ActivateApp request from HMI
+--   a. SDL does not activate the application and respond to SDL.ActivateApp
+--    with isSDLAllowed = false and isAppRevoked = true parameters
+-- 2. Consent device from HMI via SDL.OnAllowSDLFunctionality
+--   a. SDL does not activate the application
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/Defects/7_1/3580/common')
+
+--[[ Test Configuration ]]
+common.testSettings.restrictions.sdlBuildOptions = {{extendedPolicy = {"EXTERNAL_PROPRIETARY"}}}
+
+--[[ Local Data ]]
+local devices = {
+  [1] = { host = "1.0.0.1", port = config.mobilePort, hasAutoConsent = false }
+}
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Start SDL and HMI", common.startWithoutMobile)
+common.Step("Connect mobile device to SDL", common.connectMobDevices, { devices })
+common.Step("Allow SDL for device 1", common.allowSDL, { 1 })
+common.Step("Register App1 from device 1", common.registerApp, { 1, 1 })
+common.Step("Revoke app via PTU", common.revokeAppViaPtu)
+common.Step("Disallow SDL for device 1", common.disallowSDL, { 1 })
+common.Step("Ignition off", common.ignitionOff)
+common.Step("Start SDL and HMI", common.startWithoutMobile)
+common.Step("Connect mobile device to SDL", common.connectMobDevices, { devices })
+common.Step("Register App1 from device 1", common.registerAppNoPTU, { 1, false })
+
+common.Title("Test")
+common.Step("Activate App1 on device 1 without device consent", common.activateRevokedApp, { 1, false })
+common.Step("Allow SDL for device 1", common.consentDevice, { 1 })
+
+common.Title("Postconditions")
+common.Step("Remove mobile devices", common.clearMobDevices, { devices })
+common.Step("Stop SDL", common.postconditions)

--- a/test_scripts/Defects/7_1/3580/common.lua
+++ b/test_scripts/Defects/7_1/3580/common.lua
@@ -1,0 +1,176 @@
+---------------------------------------------------------------------------------------------------
+-- Common module
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local actions = require("user_modules/sequences/actions")
+local utils = require("user_modules/utils")
+local events = require("events")
+local SDL = require('SDL')
+local color = require("user_modules/consts").color
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+config.defaultProtocolVersion = 2
+config.application2.registerAppInterfaceParams = config.application1.registerAppInterfaceParams
+
+if config.defaultMobileAdapterType ~= "TCP" then
+  runner.skipTest("Test is applicable only for TCP connection")
+end
+
+--[[ Shared Functions ]]
+local m = {}
+m.Title = runner.Title
+m.Step = runner.Step
+m.testSettings = runner.testSettings
+m.preconditions = actions.preconditions
+m.postconditions = actions.postconditions
+m.allowSDL = actions.mobile.allowSDL
+
+--[[ Common Functions ]]
+function m.startWithoutMobile(pHMIParams)
+  local event = events.Event()
+  event.matches = function(e1, e2) return e1 == e2 end
+  actions.init.SDL()
+  :Do(function()
+    actions.init.HMI()
+      :Do(function()
+        actions.init.HMI_onReady(pHMIParams)
+          :Do(function()
+            actions.hmi.getConnection():RaiseEvent(event, "Start event")
+            end)
+        end)
+    end)
+  return actions.hmi.getConnection():ExpectEvent(event, "Start event")
+end
+
+local function connectMobDevice(pMobConnId, pDeviceInfo, pIsSDLAllowed)
+  if pIsSDLAllowed == nil then pIsSDLAllowed = true end
+  utils.addNetworkInterface(pMobConnId, pDeviceInfo.host)
+  actions.mobile.createConnection(pMobConnId, pDeviceInfo.host, pDeviceInfo.port)
+  local mobConnectExp = actions.mobile.connect(pMobConnId)
+  if pIsSDLAllowed then
+    mobConnectExp:Do(function()
+      actions.mobile.allowSDL(pMobConnId)
+      end)
+  end
+end
+
+function m.deleteMobDevice(pMobConnId)
+  utils.deleteNetworkInterface(pMobConnId)
+end
+
+function m.connectMobDevices(pDevices)
+  for i = 1, #pDevices do
+    connectMobDevice(i, pDevices[i], pDevices[i].hasAutoConsent)
+  end
+end
+
+function m.clearMobDevices(pDevices)
+  for i = 1, #pDevices do
+    m.deleteMobDevice(i)
+  end
+end
+
+local function registerApp(pAppId, pMobConnId, hasPTU)
+  if not pAppId then pAppId = 1 end
+  if not pMobConnId then pMobConnId = 1 end
+  local session = actions.mobile.createSession(pAppId, pMobConnId)
+  session:StartService(7)
+  :Do(function()
+      local corId = session:SendRPC("RegisterAppInterface", actions.app.getParams(pAppId))
+      actions.hmi.getConnection():ExpectNotification("BasicCommunication.OnAppRegistered",
+        { application = { appName = actions.app.getParams(pAppId).appName } })
+      :Do(function(_, d1)
+          actions.app.setHMIId(d1.params.application.appID, pAppId)
+          if hasPTU then
+            actions.ptu.expectStart()
+          end
+        end)
+      session:ExpectResponse(corId, { success = true, resultCode = "SUCCESS" })
+      :Do(function()
+          session:ExpectNotification("OnHMIStatus",
+            { hmiLevel = "NONE", audioStreamingState = "NOT_AUDIBLE", systemContext = "MAIN" })
+        end)
+    end)
+end
+
+function m.registerApp(pAppId, pMobConnId)
+  registerApp(pAppId, pMobConnId, true)
+end
+
+function m.registerAppNoPTU(pAppId, pMobConnId)
+  registerApp(pAppId, pMobConnId, false)
+end
+
+function m.activateRevokedApp(pAppId, pIsSdlAllowed)
+  actions.mobile.getSession(pAppId):ExpectNotification("OnHMIStatus"):Times(0)
+  local requestId = actions.hmi.getConnection():SendRequest("SDL.ActivateApp", { appID = actions.app.getHMIId(pAppId) })
+  actions.hmi.getConnection():ExpectResponse(requestId,
+    { result = { isSDLAllowed = pIsSdlAllowed, isAppRevoked = true } })
+end
+
+function m.disallowSDL(pMobConnId)
+  if pMobConnId == nil then pMobConnId = 1 end
+  local connection = actions.mobile.getConnection(pMobConnId)
+  local hmi = actions.hmi.getConnection()
+  local event = actions.run.createEvent()
+  hmi:SendNotification("SDL.OnAllowSDLFunctionality", {
+    allowed = false,
+    source = "GUI",
+    device = {
+      id = utils.getDeviceMAC(connection.host, connection.port),
+      name = utils.getDeviceName(connection.host, connection.port)
+    }
+  })
+  actions.run.runAfter(function() hmi:RaiseEvent(event, "Disallow SDL event") end, 500)
+  return hmi:ExpectEvent(event, "Disallow SDL event")
+end
+
+function m.consentDevice(pDeviceId)
+  for _, session in pairs(actions.mobile.getApps(pDeviceId)) do
+    session:ExpectNotification("OnHMIStatus"):Times(0)
+  end
+  actions.hmi.getConnection():ExpectRequest("BasicCommunication.ActivateApp"):Times(0)
+  actions.mobile.allowSDL(pDeviceId)
+end
+
+local function policyUpdate(pPolicyTable)
+  pPolicyTable.policy_table.functional_groupings["DataConsent-2"].rpcs = actions.json.null
+  pPolicyTable.policy_table.app_policies[actions.app.getPolicyAppId(1)] = actions.json.null
+end
+
+function m.revokeAppViaPtu()
+  actions.ptu.policyTableUpdate(policyUpdate)
+end
+
+function m.revokeAppViaPreloadedPT()
+  local pt = actions.sdl.getPreloadedPT()
+  policyUpdate(pt)
+  actions.sdl.setPreloadedPT(pt)
+end
+
+function m.ignitionOff()
+  local isOnSDLCloseSent = false
+  local hmi = actions.hmi.getConnection()
+  hmi:SendNotification("BasicCommunication.OnExitAllApplications", { reason = "SUSPEND" })
+  hmi:ExpectNotification("BasicCommunication.OnSDLPersistenceComplete")
+  :Do(function()
+    hmi:SendNotification("BasicCommunication.OnExitAllApplications", { reason = "IGNITION_OFF" })
+    hmi:ExpectNotification("BasicCommunication.OnSDLClose")
+    :Do(function()
+      isOnSDLCloseSent = true
+      SDL.DeleteFile()
+    end)
+  end)
+  actions.run.wait(3000)
+  :Do(function()
+    if isOnSDLCloseSent == false then utils.cprint(color.magenta, "BC.OnSDLClose was not sent") end
+    for i = 1, actions.mobile.getAppsCount() do
+      actions.mobile.deleteSession(i)
+    end
+    StopSDL()
+  end)
+end
+
+return m

--- a/test_sets/Defects/Defects_release_7_1.txt
+++ b/test_sets/Defects/Defects_release_7_1.txt
@@ -1,0 +1,3 @@
+;Revoked application activation
+./test_scripts/Defects/7_1/3580/001_revoked_app_activation_after_device_consent_ptu.lua
+./test_scripts/Defects/7_1/3580/002_revoked_app_activation_after_device_consent_ignition_off.lua


### PR DESCRIPTION
ATF Test Scripts to check #[FORDTCN-10972](https://adc.luxoft.com/jira/browse/FORDTCN-10972)

This PR is **ready** for review.

### Summary
Scripts to check 3580 issue

### ATF version
develop

### Changelog
 - Added scripts to check 3580 issue

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
