### PR TITLE
[SDL-0117] Configurable time before shutdown

### DIFF
--- a/test_scripts/TimeBeforeShutdown/001_SDL_takes_into_account_MaxTimeBeforeShutdown.lua
+++ b/test_scripts/TimeBeforeShutdown/001_SDL_takes_into_account_MaxTimeBeforeShutdown.lua
@@ -1,0 +1,32 @@
+----------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0117-configurable-time-before-shutdown.md
+--
+-- Description: Check SDL takes into account the value of 'MaxTimeBeforeShutdown' parameter during shut down sequence
+-- in case if 'FlushLogMessagesBeforeShutdown' = true
+--
+-- In case:
+-- 1. In SDL .ini 'FlushLogMessagesBeforeShutdown' = true and 'MaxTimeBeforeShutdown' = 10
+-- 2. HMI sends 'BC.OnExitAllApplications(IGNITION_OFF)' notification to SDL
+-- SDL does:
+--  - shut down within 'MaxTimeBeforeShutdown' duration.
+--  - not wait until all logs are written
+----------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/TimeBeforeShutdown/common')
+
+--[[ Conditions to skip test ]]
+common.isTestApplicable()
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Set SDL .ini params", common.setSDLIniParams, {
+  { FlushLogMessagesBeforeShutdown = "true", MaxTimeBeforeShutdown = 10 } })
+
+common.Title("Test")
+common.Step("Start SDL, init HMI", common.start)
+common.Step("Ignition Off", common.ignitionOff, { 10 })
+common.Step("Check SDL log is not complete", common.checkSDLLog, { common.logNotComplete })
+
+common.Title("Postconditions")
+common.Step("Clean environment", common.postconditions)

--- a/test_scripts/TimeBeforeShutdown/002_SDL_ignores_MaxTimeBeforeShutdown.lua
+++ b/test_scripts/TimeBeforeShutdown/002_SDL_ignores_MaxTimeBeforeShutdown.lua
@@ -1,0 +1,32 @@
+----------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0117-configurable-time-before-shutdown.md
+--
+-- Description: Check SDL ignores the value of 'MaxTimeBeforeShutdown' parameter during shut down sequence
+-- in case if 'FlushLogMessagesBeforeShutdown' = false
+--
+-- In case:
+-- 1. In SDL .ini 'FlushLogMessagesBeforeShutdown' = false and 'MaxTimeBeforeShutdown' = 10
+-- 2. HMI sends 'BC.OnExitAllApplications(IGNITION_OFF)' notification to SDL
+-- SDL does:
+--  - shut down without timeout (as soon as possible)
+--  - not wait until all logs are written
+----------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/TimeBeforeShutdown/common')
+
+--[[ Conditions to skip test ]]
+common.isTestApplicable()
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Set SDL .ini params", common.setSDLIniParams, {
+  { FlushLogMessagesBeforeShutdown = "false", MaxTimeBeforeShutdown = 10 } })
+
+common.Title("Test")
+common.Step("Start SDL, init HMI", common.start)
+common.Step("Ignition Off", common.ignitionOff, { 1 })
+common.Step("Check SDL log is not complete", common.checkSDLLog, { common.logNotComplete })
+
+common.Title("Postconditions")
+common.Step("Clean environment", common.postconditions)

--- a/test_scripts/TimeBeforeShutdown/003_SDL_saves_all_logs.lua
+++ b/test_scripts/TimeBeforeShutdown/003_SDL_saves_all_logs.lua
@@ -1,0 +1,31 @@
+----------------------------------------------------------------------------------------------------
+-- Proposal: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0117-configurable-time-before-shutdown.md
+--
+-- Description: Check SDL is able to save all logs during shut down sequence
+-- if the value of 'MaxTimeBeforeShutdown' parameter is big enough and 'FlushLogMessagesBeforeShutdown' = true
+--
+-- In case:
+-- 1. In SDL .ini 'FlushLogMessagesBeforeShutdown' = true and 'MaxTimeBeforeShutdown' = 60
+-- 2. HMI sends 'BC.OnExitAllApplications(IGNITION_OFF)' notification to SDL
+-- SDL does:
+--  - shut down once all logs are written
+----------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local common = require('test_scripts/TimeBeforeShutdown/common')
+
+--[[ Conditions to skip test ]]
+common.isTestApplicable()
+
+--[[ Scenario ]]
+common.Title("Preconditions")
+common.Step("Clean environment", common.preconditions)
+common.Step("Set SDL .ini params", common.setSDLIniParams, {
+  { FlushLogMessagesBeforeShutdown = "true", MaxTimeBeforeShutdown = 60 } })
+
+common.Title("Test")
+common.Step("Start SDL, init HMI", common.start)
+common.Step("Ignition Off", common.ignitionOff, { nil })
+common.Step("Check SDL log is complete", common.checkSDLLog, { common.logComplete })
+
+common.Title("Postconditions")
+common.Step("Clean environment", common.postconditions)

--- a/test_scripts/TimeBeforeShutdown/common.lua
+++ b/test_scripts/TimeBeforeShutdown/common.lua
@@ -1,0 +1,191 @@
+---------------------------------------------------------------------------------------------------
+-- Common module
+---------------------------------------------------------------------------------------------------
+--[[ Required Shared libraries ]]
+local runner = require('user_modules/script_runner')
+local actions = require('user_modules/sequences/actions')
+local utils = require("user_modules/utils")
+local atf_logger = require("atf_logger")
+local color = require("user_modules/consts").color
+local SDL = require('SDL')
+
+--[[ Test Configuration ]]
+runner.testSettings.isSelfIncluded = false
+config.ExitOnCrash = false
+config.defaultProtocolVersion = 3
+
+--[[ Module ]]
+local m = {}
+
+--[[ Common Proxy Functions ]]
+do
+  m.Title = runner.Title
+  m.Step = runner.Step
+  m.skipTest = runner.skipTest
+end
+
+--[[ Common Constants ]]
+m.logComplete = true
+m.logNotComplete = false
+
+--[[ Local Constants ]]
+local ping = 1000 --ms
+local timeout = 120000
+local delay = 5000
+local slowDriveDir = "slowdrv"
+local sdlLogFileParamName = "log4j.appender.SmartDeviceLinkCoreLogFile.File"
+
+--[[ Local Variables ]]
+local loopDevice
+local sdlLogFileParamCurrentValue
+local sdlLogFileParamNewValue
+local ts_start
+local ts_finish
+
+--[[ Module Functions ]]
+function m.log(...)
+  local str = "[" .. atf_logger.formated_time(true) .. "]"
+  for i, p in pairs({...}) do
+    local delimiter = "\t"
+    if i == 1 then delimiter = " " end
+    str = str .. delimiter .. tostring(p)
+  end
+  utils.cprint(color.magenta, str)
+end
+
+function m.execCmd(pCmd)
+  local handle = io.popen(pCmd)
+  local result = handle:read("*a")
+  handle:close()
+  return (string.gsub(result, "\n", ""))
+end
+
+local function getSDLLogInfo()
+  return m.execCmd("wc -l -c " .. sdlLogFileParamNewValue .. " | awk '{print $1,$2}'")
+end
+
+function m.ignitionOff(pExpDuration)
+  local event = actions.run.createEvent()
+  actions.getHMIConnection():SendNotification("BasicCommunication.OnExitAllApplications", { reason = "SUSPEND" })
+  actions.getHMIConnection():ExpectNotification("BasicCommunication.OnSDLPersistenceComplete")
+  :Do(function()
+      actions.getHMIConnection():SendNotification("BasicCommunication.OnExitAllApplications", { reason = "IGNITION_OFF" })
+      m.log("BC.OnExitAllApplications")
+      ts_start = timestamp()
+      actions.getHMIConnection():ExpectNotification("BasicCommunication.OnSDLClose")
+      :Do(function()
+          m.log("BC.OnSDLClose")
+        end)
+      local pid = m.execCmd("cat sdl.pid")
+      m.log("SDL pid:", pid)
+      local pCnt = 0
+      local function waitForShutdown()
+        if actions.sdl.isRunning() then
+          pCnt = pCnt + 1
+          m.log(".", pCnt, getSDLLogInfo())
+          actions.run.runAfter(waitForShutdown, ping)
+        else
+          SDL.DeleteFile()
+          ts_finish = timestamp()
+          local actualDuration = (ts_finish - ts_start) / 1000
+          local tolerance = 1.5 -- s
+          m.log("SDL stopped, shutdown duration (s):", actualDuration)
+          actions.getHMIConnection():RaiseEvent(event, "SDL stop event")
+          if pExpDuration ~= nil
+            and (actualDuration > pExpDuration + tolerance or actualDuration < pExpDuration - tolerance) then
+            actions.run.fail("Expected shut down duration (s): " .. pExpDuration)
+          end
+          return
+        end
+      end
+      actions.run.runAfter(waitForShutdown, ping)
+    end)
+  actions.getHMIConnection():ExpectEvent(event, "SDL stop event")
+  :Timeout(timeout)
+end
+
+function m.start()
+  local event = actions.run.createEvent()
+  actions.init.SDL()
+  :Do(function()
+      actions.init.HMI()
+      :Do(function()
+          actions.hmi.getConnection():RaiseEvent(event, "Start event")
+          actions.run.wait(delay)
+        end)
+    end)
+  return actions.hmi.getConnection():ExpectEvent(event, "Start event")
+end
+
+local function updateSDLLoggerConfig()
+  sdlLogFileParamCurrentValue = SDL.LOGGER.get(sdlLogFileParamName)
+  sdlLogFileParamNewValue = m.execCmd("pwd") .. "/" .. slowDriveDir .. "/" .. sdlLogFileParamCurrentValue
+  SDL.LOGGER.set(sdlLogFileParamName, sdlLogFileParamNewValue)
+end
+
+local function mountSlowDrive()
+  loopDevice = m.execCmd("echo $LOOP_DEVICE")
+  if string.len(loopDevice) == 0 then
+    actions.run.fail("Loop Device is not accessible")
+    return
+  end
+  m.log("Loop Device:", loopDevice)
+  local id = string.gsub(loopDevice, "/dev/loop", "")
+  m.log("Loop Device Id:", id)
+  slowDriveDir = slowDriveDir .. "_" .. id
+  m.execCmd("mkdir " .. slowDriveDir)
+  m.execCmd("sudo mount -o sync " .. loopDevice .. " " .. m.execCmd("pwd") .. "/" .. slowDriveDir)
+  m.log(m.execCmd("sudo chown -R `id -u`:`id -g` " .. slowDriveDir))
+  m.log(m.execCmd("dd if=/dev/zero of=" .. slowDriveDir .. "/speed_test count=500; rm " .. slowDriveDir .. "/speed_test;"))
+end
+
+function m.preconditions()
+  mountSlowDrive()
+  actions.preconditions()
+  updateSDLLoggerConfig()
+end
+
+local function copySDLLog()
+  os.execute("cp " .. sdlLogFileParamNewValue .. " " .. config.pathToSDL)
+end
+
+local function restoreSDLLoggerConfig()
+  SDL.LOGGER.set(sdlLogFileParamName, sdlLogFileParamCurrentValue)
+end
+
+local function umountSlowDrive()
+  if string.len(loopDevice) ~= 0 then
+    m.execCmd("sudo umount -f " .. loopDevice)
+    m.execCmd("rm -rf " .. slowDriveDir)
+  end
+end
+
+function m.postconditions()
+  copySDLLog()
+  actions.postconditions()
+  restoreSDLLoggerConfig()
+  umountSlowDrive()
+end
+
+function m.setSDLIniParams(pParamValues)
+  for p, v in pairs(pParamValues) do
+    actions.sdl.setSDLIniParameter(p, v)
+  end
+end
+
+function m.checkSDLLog(pExpLogState)
+  local successMsg = "Application has been stopped successfuly"
+  local res = m.execCmd("grep '" .. successMsg .. "' " .. sdlLogFileParamNewValue .. " | wc -l")
+  local actualLogState = res == "1" and true or false
+  if actualLogState ~= pExpLogState then
+    actions.run.fail("SDL log is expected to be " .. (pExpLogState and "complete" or "not complete"))
+  end
+end
+
+function m.isTestApplicable()
+  if m.execCmd("grep :/docker /proc/self/cgroup | wc -l") == "0" then
+    runner.skipTest("Script is unable to be run in consecutive mode (only parallel mode is supported)")
+  end
+end
+
+return m

--- a/test_sets/configurable_time_before_shutdown.txt
+++ b/test_sets/configurable_time_before_shutdown.txt
@@ -1,0 +1,3 @@
+./test_scripts/TimeBeforeShutdown/001_SDL_takes_into_account_MaxTimeBeforeShutdown.lua
+./test_scripts/TimeBeforeShutdown/002_SDL_ignores_MaxTimeBeforeShutdown.lua
+./test_scripts/TimeBeforeShutdown/003_SDL_saves_all_logs.lua


### PR DESCRIPTION
ATF Test Scripts to check [SDL-0117 Configurable time before shutdown](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0117-configurable-time-before-shutdown.md) feature (and corresponding issue in core: `https://github.com/smartdevicelink/sdl_core/issues/1941`)

This PR is **[ready]** for review.

### Summary
New scripts to verify feature

### ATF version
[Slow drive support](https://github.com/LuxoftSDL/sdl_atf/pull/8)

### Changelog
 - Added new scripts for feature
 - Added new test set 

### Notes 
Since these scripts require specific version of ATF they can't considered as part of regression scope.
Appropriate changes in ATF (published in [PR#8](https://github.com/LuxoftSDL/sdl_atf/pull/8)) may be extended and to be delivered as a feature. After that scripts can be included into regression.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
