### PR TITLE
Changed messagecode for ActivateApp for revoked app

### DIFF
--- a/test_scripts/API/ATF_OnAppInterfaceUnregistered.lua
+++ b/test_scripts/API/ATF_OnAppInterfaceUnregistered.lua
@@ -1738,7 +1738,7 @@ local function TC_APPLINK_18428_AppPermissionIsNull()
 		EXPECT_HMINOTIFICATION("SDL.OnAppPermissionChanged", {appID = self.applications["AppNullPermission"], appRevoked =  true, priority = "EMERGENCY"})
 			:Do(function(_,data)
 				--hmi side: sending SDL.GetUserFriendlyMessage request to SDL
-				local RequestIdGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {"AppUnsupported"}})
+				local RequestIdGetUserFriendlyMessage = self.hmiConnection:SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {"AppUnauthorized"}})
 			
 				--hmi side: expect BC.ActivateApp 
 				EXPECT_HMICALL("BasicCommunication.ActivateApp",{appID=self.applications["AppNullPermission"],level="NONE",priority="NONE"})
@@ -1752,10 +1752,10 @@ local function TC_APPLINK_18428_AppPermissionIsNull()
 					self.hmiConnection:SendResponse(data.id,data.method, "SUCCESS",{})
 				end)	
 				EXPECT_HMIRESPONSE(RequestIdGetUserFriendlyMessage,{result = {code = 0, method = "SDL.GetUserFriendlyMessage", messages = {{
-												line1 = "Not Supported", 
-												messageCode = "AppUnsupported", 
-												textBody = "Your version of %appName% is not supported by SYNC.",
-												ttsString = "This version of %appName% is not supported by SYNC."}}}})
+												line1 = "Not Authorized",
+												messageCode = "AppUnauthorized",
+												textBody = "This version of %appName% is no longer authorized to work with AppLink. Please update to the latest version of %appName%.",
+												ttsString = "This version of %appName% is not authorized and will not work with SYNC."}}}})
 			end)
 		--mobile side: expect notification
 		EXPECT_NOTIFICATION("OnHMIStatus", {hmiLevel = "NONE", systemContext = "MAIN"}) 

--- a/test_scripts/Defects/7_1/3580_Revoked_app_activated_via_device_consent.lua
+++ b/test_scripts/Defects/7_1/3580_Revoked_app_activated_via_device_consent.lua
@@ -49,7 +49,7 @@ local function activateApp(pAppId)
     }})
   :Do(function(_,_)
       local RequestId1 = common.getHMIConnection():SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {"DataConsent"}})
-      local RequestId2 = common.getHMIConnection():SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {"AppUnsupported"}})
+      local RequestId2 = common.getHMIConnection():SendRequest("SDL.GetUserFriendlyMessage", {language = "EN-US", messageCodes = {"AppUnauthorized"}})
 
       common.getHMIConnection():ExpectResponse(RequestId1, {result = {code = 0, method = "SDL.GetUserFriendlyMessage"}})
       :Do(function(_,_)


### PR DESCRIPTION
Update for [#12619](https://adc.luxoft.com/jira/browse/FORDTCN-12619)

This PR is **[ready]** for review.

### Summary
Message with AppUnauthorized code is more obvious for users when application is revoked.

### ATF version
develop

### Changelog
- Change massage code in applicable scripts

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
