### PR TITLE
[internal review] Extend coverage for issue 3802

### DIFF
--- a/test_scripts/Resumption/Handling_errors_from_HMI/007_resume_all_data_with_one_error_rpc_2apps_unexpected_disconnect.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/007_resume_all_data_with_one_error_rpc_2apps_unexpected_disconnect.lua
@@ -38,7 +38,7 @@ local rpcs = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   subscribeVehicleData = { "VehicleInfo" },
   getInteriorVehicleData = { "RC" },
   createWindow = { "UI" },
@@ -49,7 +49,7 @@ local rpcsForApp2 = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   createWindow = { "UI" },
   subscribeButton = { "Buttons" }
 }

--- a/test_scripts/Resumption/Handling_errors_from_HMI/008_resume_all_data_with_one_error_rpc_2apps_ign_off.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/008_resume_all_data_with_one_error_rpc_2apps_ign_off.lua
@@ -38,7 +38,7 @@ local rpcs = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   subscribeVehicleData = { "VehicleInfo" },
   getInteriorVehicleData = { "RC" },
   createWindow = { "UI" },
@@ -49,7 +49,7 @@ local rpcsForApp2 = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   createWindow = { "UI" },
   subscribeButton = { "Buttons" }
 }

--- a/test_scripts/Resumption/Handling_errors_from_HMI/019_resume_all_data_without_response_to_one_rpc_2apps_unexpected_disconnect.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/019_resume_all_data_without_response_to_one_rpc_2apps_unexpected_disconnect.lua
@@ -38,7 +38,7 @@ local rpcs = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   subscribeVehicleData = { "VehicleInfo" },
   getInteriorVehicleData = { "RC" },
   createWindow = { "UI" },
@@ -49,7 +49,7 @@ local rpcsForApp2 = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   createWindow = { "UI" },
   subscribeButton = { "Buttons" }
 }

--- a/test_scripts/Resumption/Handling_errors_from_HMI/020_resume_all_data_without_response_to_one_rpc_2apps_ign_off.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/020_resume_all_data_without_response_to_one_rpc_2apps_ign_off.lua
@@ -38,7 +38,7 @@ local rpcs = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   subscribeVehicleData = { "VehicleInfo" },
   getInteriorVehicleData = { "RC" },
   createWindow = { "UI" },
@@ -49,7 +49,7 @@ local rpcsForApp2 = {
   addCommand = { "UI", "VR" },
   addSubMenu = { "UI" },
   createIntrerationChoiceSet = { "VR" },
-  setGlobalProperties = { "UI", "TTS" },
+  setGlobalProperties = { "UI", "TTS", "RC" },
   createWindow = { "UI" },
   subscribeButton = { "Buttons" }
 }


### PR DESCRIPTION
ATF Test Scripts to check [FORDTCN-12618](https://luxproject.luxoft.com/jira/browse/FORDTCN-12618)

This PR is **[ready]** for review.

### Summary
Extend coverage ResumptionErrorHandling scripts with RC.SetGlobalProperties for issue 3802

Tests to check issue:
./test_scripts/Resumption/Handling_errors_from_HMI/013_resume_one_rpc_late_response_unexpected_disconnect.lua
./test_scripts/Resumption/Handling_errors_from_HMI/014_resume_one_rpc_late_response_ign_off.lua
./test_scripts/Resumption/Handling_errors_from_HMI/015_resume_one_rpc_without_response_unexpected_disconnect.lua
./test_scripts/Resumption/Handling_errors_from_HMI/016_resume_one_rpc_without_response_ign_off.lua
./test_scripts/Resumption/Handling_errors_from_HMI/017_resume_all_data_without_response_to_one_rpc_unexpected_disconnect.lua
./test_scripts/Resumption/Handling_errors_from_HMI/018_resume_all_data_without_response_to_one_rpc_ign_off.lua
./test_scripts/Resumption/Handling_errors_from_HMI/019_resume_all_data_without_response_to_one_rpc_2apps_unexpected_disconnect.lua
./test_scripts/Resumption/Handling_errors_from_HMI/020_resume_all_data_without_response_to_one_rpc_2apps_ign_off.lua

### ATF version
develop

### Changelog
Extend ResumptionErrorHandling scripts for RC.SetGlobalProperties




