### PR TITLE
Test scripts for issue 12996 [internal review]

### DIFF
--- a/test_scripts/Resumption/Handling_errors_from_HMI/013_resume_one_rpc_late_response_unexpected_disconnect.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/013_resume_one_rpc_late_response_unexpected_disconnect.lua
@@ -33,7 +33,7 @@ function common.sendResponse(pData, pErrorRespInterface, pCurrentInterface)
     common.getHMIConnection():SendResponse(pData.id, pData.method, "SUCCESS", common.getSuccessHMIResponseData(pData))
   end
   if pErrorRespInterface ~= nil and pErrorRespInterface == pCurrentInterface then
-    common.run.runAfter(response, 11000)
+    common.run.runAfter(response, common.defaultTimeoutWithCompensation + 1000)
   else
     response()
   end

--- a/test_scripts/Resumption/Handling_errors_from_HMI/014_resume_one_rpc_late_response_ign_off.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/014_resume_one_rpc_late_response_ign_off.lua
@@ -33,7 +33,7 @@ function common.sendResponse(pData, pErrorRespInterface, pCurrentInterface)
     common.getHMIConnection():SendResponse(pData.id, pData.method, "SUCCESS", common.getSuccessHMIResponseData(pData))
   end
   if pErrorRespInterface ~= nil and pErrorRespInterface == pCurrentInterface then
-    common.run.runAfter(response, 11000)
+    common.run.runAfter(response, common.defaultTimeoutWithCompensation + 1000)
   else
     response()
   end

--- a/test_scripts/Resumption/Handling_errors_from_HMI/commonResumptionErrorHandling.lua
+++ b/test_scripts/Resumption/Handling_errors_from_HMI/commonResumptionErrorHandling.lua
@@ -70,6 +70,10 @@ m.timeToRegApp2 = {
   AFTER_ERRONEOUS_RESPONSE = 3,
 }
 
+local defaultTimeout = actions.sdl.getSDLIniParameter("DefaultTimeout")
+local defaultTimeoutCompensation = actions.sdl.getSDLIniParameter("DefaultTimeoutCompensation")
+m.defaultTimeoutWithCompensation = defaultTimeout + defaultTimeoutCompensation
+
 --[[ Local Functions ]]
 
 --[[ @getOnSCUParams: return parameters for OnSystemCapabilityUpdated


### PR DESCRIPTION
ATF Test Scripts to check [FORDTCN-12996](https://luxproject.luxoft.com/jira/browse/FORDTCN-12996)

This PR is **[ready ]** for review.

### Summary
Improve stability Reregister App resumption  in scripts: 
./test_scripts/Resumption/Handling_errors_from_HMI/013_resume_one_rpc_late_response_unexpected_disconnect.lua	
./test_scripts/Resumption/Handling_errors_from_HMI/014_resume_one_rpc_late_response_ign_off.lua	
Added defaultTimeoutCompensation for HMI response

###ATF version
latest

### Changelog
add defaultTimeoutCompensation for HMI response

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
